### PR TITLE
Replace alerts with in-app messages

### DIFF
--- a/client/game.css
+++ b/client/game.css
@@ -84,3 +84,10 @@ ul {
 #opponentStatus {
     margin-bottom: 10px;
 }
+
+.status-message {
+    margin-top: 20px;
+    text-align: center;
+    color: #ff5;
+    font-weight: bold;
+}

--- a/client/game.html
+++ b/client/game.html
@@ -30,6 +30,7 @@
     <ul id="opponentGuesses"></ul>
   </div>
 </div>
+<div id="gameMessage" class="status-message"></div>
 
 <script src="game.js"></script>
 </body>

--- a/client/game.js
+++ b/client/game.js
@@ -9,6 +9,13 @@ const yourGuesses = document.getElementById('yourGuesses');
 const opponentGuesses = document.getElementById('opponentGuesses');
 const turnBanner = document.getElementById('yourTurnBanner');
 const opponentStatus = document.getElementById('opponentStatus');
+const messageEl = document.getElementById('gameMessage');
+
+function showMessage(msg) {
+    if (messageEl) {
+        messageEl.textContent = msg;
+    }
+}
 
 let wordSet = new Set();
 let isMyTurn = false;
@@ -88,7 +95,7 @@ function updateUI(state) {
 
     if (state.winner != null) {
         const youWon = state.winner === playerId;
-        alert(youWon ? '🏆 You win!' : '😢 You lose...');
+        showMessage(youWon ? '🏆 You win!' : '😢 You lose...');
         guessInput.disabled = true;
         clearInterval(pollInterval);
     }

--- a/client/index.html
+++ b/client/index.html
@@ -20,6 +20,7 @@
     </div>
 
 </div>
+<div id="mainMessage" class="status-message"></div>
 
 
 

--- a/client/lobby.html
+++ b/client/lobby.html
@@ -123,10 +123,14 @@
   const API = 'http://localhost:3000'; // Change to production later
   let lobbyId = '';
   let playerId = null;
+  const statusEl = document.getElementById('lobbyStatus');
 
   async function createLobby() {
     const name = document.getElementById('playerName').value.trim();
-    if (!name) return alert('Enter a name');
+    if (!name) {
+      statusEl.textContent = 'Enter a name';
+      return;
+    }
 
     const res = await fetch(`${API}/create-lobby`, { method: 'POST' });
     const data = await res.json();
@@ -137,7 +141,10 @@
   async function joinLobby() {
     const name = document.getElementById('playerName').value.trim();
     const inputId = document.getElementById('lobbyIdInput').value.trim();
-    if (!name || !inputId) return alert('Enter name and lobby ID');
+    if (!name || !inputId) {
+      statusEl.textContent = 'Enter name and lobby ID';
+      return;
+    }
     joinLobbyInternal(name, inputId);
   }
 
@@ -150,7 +157,8 @@
 
     const data = await res.json();
     if (data.playerId === undefined) {
-      return alert('Failed to join lobby');
+      statusEl.textContent = 'Failed to join lobby';
+      return;
     }
 
     lobbyId = lobbyIdToJoin;
@@ -163,7 +171,7 @@
 
   function copyLobbyId() {
     navigator.clipboard.writeText(lobbyId);
-    alert('Lobby code copied!');
+    statusEl.textContent = 'Lobby code copied!';
   }
 
   async function pollLobbyReady() {

--- a/client/main.js
+++ b/client/main.js
@@ -6,11 +6,20 @@ let forcedPrefix = '';
 const urlParams = new URLSearchParams(window.location.search);
 const lobbyId = urlParams.get('lobbyId');
 const playerId = parseInt(urlParams.get('playerId'), 10);
+const messageEl = document.getElementById('mainMessage');
+
+function showMessage(msg) {
+    if (messageEl) {
+        messageEl.textContent = msg;
+    }
+}
 
 // 🔐 Validate query params
 if (!lobbyId || isNaN(playerId)) {
-    alert('Missing lobby info. Redirecting to lobby...');
-    window.location.href = 'lobby.html';
+    if (messageEl) messageEl.textContent = 'Missing lobby info. Redirecting to lobby...';
+    setTimeout(() => {
+        window.location.href = 'lobby.html';
+    }, 1500);
 }
 
 const inputEl = document.getElementById('wordInput');
@@ -160,7 +169,7 @@ async function submitWordsToLobby() {
 
         const data = await res.json();
         if (data.status === 'ok') {
-            alert('✅ Your words were submitted. Waiting for opponent...');
+            showMessage('✅ Your words were submitted. Waiting for opponent...');
             setInterval(async () => {
                 try {
                     const res = await fetch(`http://localhost:3000/guess-state?lobbyId=${lobbyId}&playerId=${playerId}`);
@@ -174,11 +183,11 @@ async function submitWordsToLobby() {
                 }
             }, 1000);
         } else {
-            alert('❌ Submission error: ' + (data.error || 'Unknown issue'));
+            showMessage('❌ Submission error: ' + (data.error || 'Unknown issue'));
         }
     } catch (err) {
         console.error(err);
-        alert('❌ Network error during word submission');
+        showMessage('❌ Network error during word submission');
     }
 }
 

--- a/client/style.css
+++ b/client/style.css
@@ -71,6 +71,13 @@ body {
 .suggestion:hover {
     background-color: #0ff5;
 }
+
+.status-message {
+    margin-top: 20px;
+    text-align: center;
+    color: #ff5;
+    font-weight: bold;
+}
 .container {
     max-width: 320px;
     width: 100%;


### PR DESCRIPTION
## Summary
- add status message containers in game and main pages
- style new `.status-message` class
- display lobby status messages instead of alerts
- replace alerts with in-app status text across JS

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684f42f7c8e08327a65f00d7a7f13751